### PR TITLE
flannel 使用 PRIVATE_IPV4 接口进行主机间通信

### DIFF
--- a/cl.conf
+++ b/cl.conf
@@ -31,3 +31,4 @@ systemd:
 
 flannel:
   etcd_prefix: "/flannel/network"
+  interface: "{PRIVATE_IPV4}"


### PR DESCRIPTION
原因：
https://coreos.com/flannel/docs/latest/running.html#running-on-vagrant